### PR TITLE
Remove outdated numpy aliases

### DIFF
--- a/fasttreeshap/_explanation.py
+++ b/fasttreeshap/_explanation.py
@@ -798,7 +798,7 @@ def _compute_shape(x):
             if first_shape == tuple():
                 return (len(x),)
             else: # we have an array of arrays...
-                matches = np.ones(len(first_shape), dtype=np.bool)
+                matches = np.ones(len(first_shape), dtype=bool)
                 for i in range(1, len(x)):
                     shape = _compute_shape(x[i])
                     assert len(shape) == len(first_shape), "Arrays in Explanation objects must have consistent inner dimensions!"

--- a/fasttreeshap/datasets.py
+++ b/fasttreeshap/datasets.py
@@ -53,7 +53,7 @@ def imdb(display=False): # pylint: disable=unused-argument
 
     with open(cache(github_data_url + "imdb_train.txt")) as f:
         data = f.readlines()
-    y = np.ones(25000, dtype=np.bool)
+    y = np.ones(25000, dtype=bool)
     y[:12500] = 0
     return data, y
 
@@ -71,7 +71,7 @@ def communitiesandcrime(display=False): # pylint: disable=unused-argument
 
     # find the indices where the total violent crimes are known
     valid_inds = np.where(np.invert(np.isnan(raw_data.iloc[:,-2])))[0]
-    y = np.array(raw_data.iloc[valid_inds,-2], dtype=np.float)
+    y = np.array(raw_data.iloc[valid_inds,-2], dtype=float)
 
     # extract the predictive features and remove columns with missing values
     X = raw_data.iloc[valid_inds,5:-18]

--- a/fasttreeshap/explainers/_explainer.py
+++ b/fasttreeshap/explainers/_explainer.py
@@ -291,7 +291,7 @@ class Explainer(Serializable):
         """
 
         # mask each input on in isolation
-        masks = np.zeros(2*len(inds)-1, dtype=np.int)
+        masks = np.zeros(2*len(inds)-1, dtype=int)
         last_ind = -1
         for i in range(len(inds)):
             if i > 0:

--- a/fasttreeshap/explainers/_tree.py
+++ b/fasttreeshap/explainers/_tree.py
@@ -291,7 +291,7 @@ class Tree(Explainer):
             X = X.reshape(1, X.shape[0])
         if X.dtype != self.model.input_dtype:
             X = X.astype(self.model.input_dtype)
-        X_missing = np.isnan(X, dtype=np.bool)
+        X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 
@@ -1182,7 +1182,7 @@ class TreeEnsemble:
             X = X.reshape(1, X.shape[0])
         if X.dtype.type != self.input_dtype:
             X = X.astype(self.input_dtype)
-        X_missing = np.isnan(X, dtype=np.bool)
+        X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 

--- a/fasttreeshap/explainers/_tree.py
+++ b/fasttreeshap/explainers/_tree.py
@@ -1602,8 +1602,8 @@ class XGBTreeModelLoader(object):
 
     def get_trees(self, data=None, data_missing=None):
         shape = (self.num_trees, self.num_nodes.max())
-        self.children_default = np.zeros(shape, dtype=np.int)
-        self.features = np.zeros(shape, dtype=np.int)
+        self.children_default = np.zeros(shape, dtype=int)
+        self.features = np.zeros(shape, dtype=int)
         self.thresholds = np.zeros(shape, dtype=np.float32)
         self.values = np.zeros((shape[0], shape[1], 1), dtype=np.float32)
         trees = []

--- a/fasttreeshap/maskers/_image.py
+++ b/fasttreeshap/maskers/_image.py
@@ -76,7 +76,7 @@ class Image(Masker):
 
         # if mask is not given then we mask the whole image
         if mask is None:
-            mask = np.zeros(np.prod(x.shape), dtype=np.bool)
+            mask = np.zeros(np.prod(x.shape), dtype=bool)
 
         if isinstance(self.mask_value, str):
             if self.blur_kernel is not None:

--- a/fasttreeshap/maskers/_masker.py
+++ b/fasttreeshap/maskers/_masker.py
@@ -20,6 +20,6 @@ class Masker(Serializable):
                 shape = self.shape
 
             if mask is True:
-                return np.ones(shape[1], dtype=np.bool)
-            return np.zeros(shape[1], dtype=np.bool)
+                return np.ones(shape[1], dtype=bool)
+            return np.zeros(shape[1], dtype=bool)
         return mask

--- a/fasttreeshap/maskers/_tabular.py
+++ b/fasttreeshap/maskers/_tabular.py
@@ -78,7 +78,7 @@ class Tabular(Masker):
 
         # self._last_mask = np.zeros(self.data.shape[1], dtype=np.bool)
         self._masked_data = data.copy()
-        self._last_mask = np.zeros(data.shape[1], dtype=np.bool)
+        self._last_mask = np.zeros(data.shape[1], dtype=bool)
         self.shape = self.data.shape
         self.supports_delta_masking = True
         # self._last_x = None
@@ -98,9 +98,9 @@ class Tabular(Masker):
         if np.issubdtype(mask.dtype, np.integer):
 
             variants = ~self.invariants(x)
-            curr_delta_inds = np.zeros(len(mask), dtype=np.int)
+            curr_delta_inds = np.zeros(len(mask), dtype=int)
             num_masks = (mask >= 0).sum()
-            varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=np.bool)
+            varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=bool)
             masked_inputs_out = np.zeros((num_masks * self.shape[0], self.shape[1]))
             self._last_mask[:] = False
             self._masked_data[:] = self.data

--- a/fasttreeshap/maskers/_text.py
+++ b/fasttreeshap/maskers/_text.py
@@ -291,7 +291,7 @@ class Text(Masker):
         """
         self._update_s_cache(s)
 
-        invariants = np.zeros(len(self._tokenized_s), dtype=np.bool)
+        invariants = np.zeros(len(self._tokenized_s), dtype=bool)
         if self.keep_prefix > 0:
             invariants[:self.keep_prefix] = True
         if self.keep_suffix > 0:

--- a/fasttreeshap/plots/_group_difference.py
+++ b/fasttreeshap/plots/_group_difference.py
@@ -51,7 +51,7 @@ def group_difference(shap_values, group_mask, feature_names=None, xlabel=None, x
     diff = shap_values[group_mask].mean(0) - shap_values[~group_mask].mean(0)
     
     if sort is True:
-        inds = np.argsort(-np.abs(diff)).astype(np.int)
+        inds = np.argsort(-np.abs(diff)).astype(int)
     else:
         inds = np.arange(len(diff))
     

--- a/fasttreeshap/plots/_scatter.py
+++ b/fasttreeshap/plots/_scatter.py
@@ -274,11 +274,11 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         interaction_feature_values = encode_array_if_needed(features[:, interaction_index])
         cv = interaction_feature_values
         cd = display_features[:, interaction_index]
-        clow = np.nanpercentile(cv.astype(np.float), 5)
-        chigh = np.nanpercentile(cv.astype(np.float), 95)
+        clow = np.nanpercentile(cv.astype(float), 5)
+        chigh = np.nanpercentile(cv.astype(float), 95)
         if clow == chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
         if type(cd[0]) == str:
             cname_map = {}
             for i in range(len(cv)):
@@ -290,8 +290,8 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
 
         # discritize colors for categorical features
         if categorical_interaction and clow != chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
             bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
@@ -301,7 +301,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         if x_jitter > 1: x_jitter = 1
         xvals = xv.copy()
         if isinstance(xvals[0], float):
-            xvals = xvals.astype(np.float)
+            xvals = xvals.astype(float)
             xvals = xvals[~np.isnan(xvals)]
         xvals = np.unique(xvals) # returns a sorted array
         if len(xvals) >= 2:
@@ -628,11 +628,11 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         interaction_feature_values = encode_array_if_needed(features[:, interaction_index])
         cv = interaction_feature_values
         cd = display_features[:, interaction_index]
-        clow = np.nanpercentile(cv.astype(np.float), 5)
-        chigh = np.nanpercentile(cv.astype(np.float), 95)
+        clow = np.nanpercentile(cv.astype(float), 5)
+        chigh = np.nanpercentile(cv.astype(float), 95)
         if clow == chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
         if type(cd[0]) == str:
             cname_map = {}
             for i in range(len(cv)):
@@ -644,8 +644,8 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
 
         # discritize colors for categorical features
         if categorical_interaction and clow != chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
             bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
@@ -654,7 +654,7 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         if x_jitter > 1: x_jitter = 1
         xvals = xv.copy()
         if isinstance(xvals[0], float):
-            xvals = xvals.astype(np.float)
+            xvals = xvals.astype(float)
             xvals = xvals[~np.isnan(xvals)]
         xvals = np.unique(xvals) # returns a sorted array
         if len(xvals) >= 2:

--- a/fasttreeshap/utils/_general.py
+++ b/fasttreeshap/utils/_general.py
@@ -82,7 +82,7 @@ def potential_interactions(shap_values_column, shap_values_matrix):
     inc = max(min(int(len(x) / 10.0), 50), 1)
     interactions = []
     for i in range(X.shape[1]):
-        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=np.float)
+        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=float)
 
         val_other = encoded_val_other
         v = 0.0
@@ -134,7 +134,7 @@ def approximate_interactions(index, shap_values, X, feature_names=None):
     inc = max(min(int(len(x) / 10.0), 50), 1)
     interactions = []
     for i in range(X.shape[1]):
-        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=np.float)
+        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=float)
 
         val_other = encoded_val_other
         v = 0.0

--- a/fasttreeshap/utils/_masked_model.py
+++ b/fasttreeshap/utils/_masked_model.py
@@ -59,7 +59,7 @@ class MaskedModel():
             # we need to convert from delta masking to a full masking call because we were given a delta masking
             # input but the masker does not support delta masking
             else: 
-                full_masks = np.zeros((int(np.sum(masks >= 0)), self._masker_cols), dtype=np.bool)
+                full_masks = np.zeros((int(np.sum(masks >= 0)), self._masker_cols), dtype=bool)
                 _convert_delta_mask_to_full(masks, full_masks)
                 return self._full_masking_call(full_masks, zero_index=zero_index, batch_size=batch_size)
 
@@ -71,17 +71,17 @@ class MaskedModel():
         if batch_size is None:
             batch_size = len(masks)
         do_delta_masking = getattr(self.masker, "reset_delta_masking", None) is not None
-        num_varying_rows = np.zeros(len(masks), dtype=np.int)
-        batch_positions = np.zeros(len(masks)+1, dtype=np.int)
+        num_varying_rows = np.zeros(len(masks), dtype=int)
+        batch_positions = np.zeros(len(masks)+1, dtype=int)
         varying_rows = []
         if self._variants is not None:
-            delta_tmp = self._variants.copy().astype(np.int)
+            delta_tmp = self._variants.copy().astype(int)
         all_outputs = []
         for batch_ind in range(0, len(masks), batch_size):
             mask_batch = masks[batch_ind:batch_ind + batch_size]
             all_masked_inputs = []
-            num_mask_samples = np.zeros(len(mask_batch), dtype=np.int)
-            last_mask = np.zeros(mask_batch.shape[1], dtype=np.bool)
+            num_mask_samples = np.zeros(len(mask_batch), dtype=int)
+            last_mask = np.zeros(mask_batch.shape[1], dtype=bool)
             for i, mask in enumerate(mask_batch):
 
                 # mask the inputs
@@ -101,7 +101,7 @@ class MaskedModel():
 
                 # see which rows have been updated, so we can only evaluate the model on the rows we need to
                 if i == 0 or self._variants is None:
-                    varying_rows.append(np.ones(num_mask_samples[i], dtype=np.bool))
+                    varying_rows.append(np.ones(num_mask_samples[i], dtype=bool))
                     num_varying_rows[batch_ind + i] = num_mask_samples[i]
                 else:
                     # a = np.any(self._variants & delta_mask, axis=1)
@@ -191,7 +191,7 @@ class MaskedModel():
 
         subset_masked_inputs = [arg[varying_rows.reshape(-1)] for arg in masked_inputs]
 
-        batch_positions = np.zeros(len(varying_rows)+1, dtype=np.int)
+        batch_positions = np.zeros(len(varying_rows)+1, dtype=int)
         for i in range(len(varying_rows)):
             batch_positions[i+1] = batch_positions[i] + num_varying_rows[i]
 
@@ -243,7 +243,7 @@ class MaskedModel():
             inds = np.arange(len(self))
 
         # mask each potentially nonzero input in isolation
-        masks = np.zeros(2*len(inds), dtype=np.int)
+        masks = np.zeros(2*len(inds), dtype=int)
         masks[0] = MaskedModel.delta_mask_noop_value
         last_ind = -1
         for i in range(len(inds)):
@@ -412,8 +412,8 @@ def make_masks(cluster_matrix):
     rec_fill_masks(mask_matrix_inds, cluster_matrix, M)
 
     # convert the array of index lists into CSR format
-    indptr = np.zeros(len(mask_matrix_inds) + 1, dtype=np.int)
-    indices = np.zeros(np.sum([len(v) for v in mask_matrix_inds]), dtype=np.int)
+    indptr = np.zeros(len(mask_matrix_inds) + 1, dtype=int)
+    indices = np.zeros(np.sum([len(v) for v in mask_matrix_inds]), dtype=int)
     pos = 0
     for i in range(len(mask_matrix_inds)):
         inds = mask_matrix_inds[i]
@@ -421,7 +421,7 @@ def make_masks(cluster_matrix):
         pos += len(inds)
         indptr[i+1] = pos
     mask_matrix = scipy.sparse.csr_matrix(
-        (np.ones(len(indices), dtype=np.bool), indices, indptr),
+        (np.ones(len(indices), dtype=bool), indices, indptr),
         shape=(len(mask_matrix_inds), M)
     )
 

--- a/tests/explainers/common.py
+++ b/tests/explainers/common.py
@@ -52,9 +52,9 @@ def test_additivity(explainer_type, model, masker, data, **kwargs):
         for i in range(shap_values.shape[0]):
             row = shap_values[i]
             if callable(explainer.masker.shape):
-                all_on_masked = explainer.masker(np.ones(explainer.masker.shape(data[i])[1], dtype=np.bool), data[i])
+                all_on_masked = explainer.masker(np.ones(explainer.masker.shape(data[i])[1], dtype=bool), data[i])
             else:
-                all_on_masked = explainer.masker(np.ones(explainer.masker.shape[1], dtype=np.bool), data[i])
+                all_on_masked = explainer.masker(np.ones(explainer.masker.shape[1], dtype=bool), data[i])
             if not isinstance(all_on_masked, tuple):
                 all_on_masked = (all_on_masked,)
             out = explainer.model(*all_on_masked)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -462,7 +462,7 @@ def test_xgboost_mixed_types():
 
     X, y = shap.datasets.boston()
     X["LSTAT"] = X["LSTAT"].astype(np.int64)
-    X["B"] = X["B"].astype(np.bool)
+    X["B"] = X["B"].astype(bool)
     bst = xgboost.train({"learning_rate": 0.01, "silent": 1}, xgboost.DMatrix(X, label=y), 1000)
     shap_values = shap.TreeExplainer(bst).shap_values(X)
     shap.dependence_plot(0, shap_values, X, show=False)
@@ -684,7 +684,7 @@ def test_catboost():
     catboost = pytest.importorskip("catboost")
     # train catboost model
     X, y = shap.datasets.boston()
-    X["RAD"] = X["RAD"].astype(np.int)
+    X["RAD"] = X["RAD"].astype(int)
     model = catboost.CatBoostRegressor(iterations=30, learning_rate=0.1, random_seed=123)
     p = catboost.Pool(X, y, cat_features=["RAD"])
     model.fit(p, verbose=False, plot=False)

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -25,7 +25,7 @@ def test_serialization_independent_masker_dataframe():
         # deserialize masker
         new_independent_masker = shap.maskers.Independent.load(temp_serialization_file)
 
-    mask = np.ones(X.shape[1]).astype(np.int)
+    mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0
     mask[4] = 0
 
@@ -54,7 +54,7 @@ def test_serialization_independent_masker_numpy():
         # deserialize masker
         new_independent_masker = shap.maskers.Masker.load(temp_serialization_file)
 
-    mask = np.ones(X.shape[1]).astype(np.int)
+    mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0
     mask[4] = 0
 
@@ -80,7 +80,7 @@ def test_serialization_partion_masker_dataframe():
         # deserialize masker
         new_partition_masker = shap.maskers.Partition.load(temp_serialization_file)
 
-    mask = np.ones(X.shape[1]).astype(np.int)
+    mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0
     mask[4] = 0
 
@@ -107,7 +107,7 @@ def test_serialization_partion_masker_numpy():
         # deserialize masker
         new_partition_masker = shap.maskers.Masker.load(temp_serialization_file)
 
-    mask = np.ones(X.shape[1]).astype(np.int)
+    mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0
     mask[4] = 0
 


### PR DESCRIPTION
This PR removes some outdated aliases from the code. Numpy has deprecated `np.int` `np.bool` and `np.float` - these use to just point to the existing python builtin types. This change simply moves the call to these builtins. 

Fixes #20 